### PR TITLE
Incorporating personalization endpoint to find more user artists

### DIFF
--- a/run.py
+++ b/run.py
@@ -4,13 +4,13 @@ for a single user with hard coded spotify user creds
 """
 from spotifollow import albums
 from spotifollow import artists
+from spotifollow import top_artists
 from spotifollow import tracks
 from spotifollow import playlist
 from spotifollow.spotify import client
 
 def main():
-    people = artists.get_user_followed_artist()
-    artist_ids = [artist["id"] for artist in people]
+    artist_ids = artists.get_artists()
     print "Fetching artists:"
     print artist_ids
 
@@ -29,6 +29,11 @@ def main():
     playlist.add_tracks_to_playlists(track_uris_by_playlist)
 
 main()
+
+# def testing():
+#     x = top_artists.get_top_artists()
+#
+# testing()
 
 
 

--- a/spotifollow/artists.py
+++ b/spotifollow/artists.py
@@ -1,5 +1,8 @@
 from spotifollow.spotify import client
 
+def get_artists():
+    artist_ids = get_user_followed_artist() + get_top_artists()
+    return dedupe(artist_ids)
 
 def get_user_followed_artist():
     after_id = ''
@@ -9,7 +12,23 @@ def get_user_followed_artist():
         artists.extend(artist_data['artists']['items'])
         after_id = artist_data['artists']['cursors']['after']
 
-    return artists
+    return [artist['id'] for artist in artists]
+
+def get_top_artists():
+    artist_ids = []
+    ranges = ['short_term', 'medium_term','long_term']
+    for time_range in ranges:
+        artist_data = client.get_user_top_artists(time_range)
+        for artist in artist_data.get("items"):
+            artist_ids.append(artist.get("id"))
+
+    return artist_ids
+
+def dedupe(seq):
+    seen = set()
+    seen_add = seen.add
+    return [x for x in seq if not (x in seen or seen_add(x))]
+
 
 # def getUserImplicitLikedArtists(next_request, access_token, token_type):
 #     if(next_request == ''):

--- a/spotifollow/spotify/client.py
+++ b/spotifollow/spotify/client.py
@@ -1,6 +1,9 @@
 import requests
 import json
 
+# SANIKA_AUTHORIZATION = 'AQBAyBgO9VHBKUc4ArnqAFnmjdP7PTCEnlwMMI30uKqHVjXqk4cW6pWRuenmya4Du1PKF9-DUqmTmD-hBPXnBnIKF3znVcWeGOIwZ7Han3x7dCA_Ux2a4T66V9CONGl8gYPzopwt6cfvnze0wdxn-t7I3YKKqpgppKUrVIGrQyXvGtlASbutjA9Jph5C1sKDQXV-Hr-laL5yEoY3UWhGI2XoZjP6LQQiT4pkBq7ndQWSWogaPOMswBLpFBShATbXX8NxCTF8r4wqSExhSyEZSQVaOnjAKOnXD6y115Wi-mWEGa2TK8z_ywdnYD7BcPweB26tog'
+# SANIKA_REFRESH_TOKEN = 'AQBXKGXs-A9RK6MHjdeAGdqwT-KhKex3ZEG8Z0HWITFwDoKaISpUhPvrGLHLDpRXpy7hDQMFXu6X8M9m7POBs18tOvOVDfw-Te2Nk4AiBnNYR7ZiPYnyTMlaaVF1HUvjHNA'
+
 CLIENT_SECRET = ''
 CLIENT_ID = ''
 REDIRECT_URI = 'https://seatgeek.com'
@@ -25,7 +28,7 @@ URLS = {
     "top": "{0}/me/top".format(BASE_URLS.get("api"))
 }
 
-##Auth
+#Auth
 def getNewAccessToken():
     body = {
         'grant_type' : 'refresh_token',
@@ -44,10 +47,11 @@ def getAuthCode():
         'client_id' : CLIENT_ID,
         'response_type' : 'code',
         'redirect_uri' : REDIRECT_URI,
-        'scope': 'playlist-modify-private user-follow-read user-follow-modify playlist-modify-public user-library-read'
+        'scope': 'playlist-modify-private user-follow-read user-follow-modify playlist-modify-public user-library-read user-top-read'
     }
     url = "{0}".format(URLS.get("auth_code"))
     r = requests.get(url, params=params)
+    return json.loads(r.content)
 
 def getInitialAccessToken():
     body = {
@@ -57,6 +61,7 @@ def getInitialAccessToken():
     }
     url = "{0}".format(URLS.get("auth_token"))
     r = requests.post(url, auth=(CLIENT_ID, CLIENT_SECRET), data=body)
+    print json.loads(r.content)
     return json.loads(r.content)
 
 ##user
@@ -84,18 +89,18 @@ def get_user_followed_artists(after_id):
     r = requests.get(url, params=params, headers=token)
     return json.loads(r.content)
 
-# def get_user_top_artists():
-#     params = {
-#         'type': 'artist',
-#         'limit': '50',
-#     }
-#
-#     token = {
-#         'Authorization': TOKEN_TYPE + ' ' + ACCESS_TOKEN
-#     }
-#     url = "{0}/{1}".format(URLS.get("top"), "tracks")
-#     r = requests.get(url, params=params, headers=token)
-#     return json.loads(r.content)
+def get_user_top_artists(time_range):
+    params = {
+        'time_range': time_range,
+        'limit': '50',
+    }
+
+    token = {
+        'Authorization': TOKEN_TYPE + ' ' + ACCESS_TOKEN
+    }
+    url = "{0}/{1}".format(URLS.get("top"), "artists")
+    r = requests.get(url, params=params, headers=token)
+    return json.loads(r.content)
 
 #   albums https://developer.spotify.com/web-api/get-several-artists/
 def get_albums_for_artist(artist_id, offset, page_size):

--- a/spotifollow/tracks.py
+++ b/spotifollow/tracks.py
@@ -3,7 +3,7 @@ from time import mktime, strptime
 from spotifollow.spotify import client
 
 BATCH_SIZE = 20
-ALBUM_DATE_ELIGIBILITY = 30
+ALBUM_DATE_ELIGIBILITY = 7
 
 
 def get_track_uris_by_playlist(album_ids):
@@ -70,11 +70,11 @@ def format_string_timestamp_to_date(unstruct_time):
 def get_tracks_dictionary():
     tracks_dict = {
         "new_songs": {
-            "playlist_name": "Spotifollow - New Songs",
+            "playlist_name": "Spotifollow - New Songs - 3",
             "uris": []
         },
         'remix' : {
-            "playlist_name" : "Spotifollow - Remixes",
+            "playlist_name" : "Spotifollow - Remixes - 3",
             "uris" : []
         }
     }


### PR DESCRIPTION
Add in the [personalization endpoint](https://developer.spotify.com/web-api/console/get-current-user-top-artists-and-tracks/) to reduce reliance on only using a user's explicitly followed artists 